### PR TITLE
Integrate orchestrator features into new UI

### DIFF
--- a/final-main/package-lock.json
+++ b/final-main/package-lock.json
@@ -83,7 +83,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -847,7 +846,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -865,7 +863,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
       "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
@@ -880,7 +877,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -890,7 +886,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -900,14 +895,12 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -918,7 +911,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -932,7 +924,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -942,7 +933,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -956,7 +946,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3008,14 +2997,14 @@
       "version": "15.7.13",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
       "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -3026,7 +3015,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -3357,7 +3346,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3370,7 +3358,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3386,14 +3373,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -3407,7 +3392,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -3471,14 +3455,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3502,7 +3484,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -3558,7 +3539,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -3606,7 +3586,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -3631,7 +3610,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -3680,7 +3658,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3693,14 +3670,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -3717,7 +3692,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -3731,7 +3705,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -3918,14 +3891,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dom-helpers": {
@@ -3942,7 +3913,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
@@ -3984,7 +3954,6 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/esbuild": {
@@ -4263,7 +4232,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
       "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -4280,7 +4248,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -4307,7 +4274,6 @@
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
       "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -4330,7 +4296,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -4381,7 +4346,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
       "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.0",
@@ -4412,7 +4376,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -4427,7 +4390,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4446,7 +4408,6 @@
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -4467,7 +4428,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -4480,7 +4440,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4490,7 +4449,6 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -4536,7 +4494,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4605,7 +4562,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -4618,7 +4574,6 @@
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
       "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -4634,7 +4589,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4644,7 +4598,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4654,7 +4607,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -4667,7 +4619,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -4677,14 +4628,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -4700,7 +4649,6 @@
       "version": "1.21.6",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
       "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -4774,7 +4722,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -4787,7 +4734,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -5297,7 +5243,6 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/lucide-react": {
@@ -5322,7 +5267,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -5332,7 +5276,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -5359,7 +5302,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -5376,7 +5318,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -5388,7 +5329,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5431,7 +5371,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5460,7 +5399,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -5520,7 +5458,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parent-module": {
@@ -5550,7 +5487,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5560,14 +5496,12 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -5584,14 +5518,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -5604,7 +5536,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5614,7 +5545,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -5624,7 +5554,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5653,7 +5582,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -5671,7 +5599,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
       "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "camelcase-css": "^2.0.1"
@@ -5691,7 +5618,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
       "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5727,7 +5653,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5753,7 +5678,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -5767,7 +5691,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -5811,7 +5734,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6035,7 +5957,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -6045,7 +5966,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -6090,7 +6010,6 @@
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.13.0",
@@ -6118,7 +6037,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -6165,7 +6083,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6211,7 +6128,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -6224,7 +6140,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6234,7 +6149,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -6257,7 +6171,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -6267,7 +6180,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -6286,7 +6198,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -6301,7 +6212,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6311,14 +6221,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -6331,7 +6239,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -6348,7 +6255,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -6361,7 +6267,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6384,7 +6289,6 @@
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
       "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -6420,7 +6324,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6443,7 +6346,6 @@
       "version": "3.4.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -6490,7 +6392,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -6500,7 +6401,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -6519,7 +6419,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -6551,7 +6450,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tslib": {
@@ -6714,7 +6612,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vaul": {
@@ -6832,7 +6729,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6858,7 +6754,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -6877,7 +6772,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -6895,7 +6789,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6905,14 +6798,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -6927,7 +6818,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -6940,7 +6830,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6974,7 +6863,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
       "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/final-main/src/App.tsx
+++ b/final-main/src/App.tsx
@@ -22,6 +22,7 @@ const App = () => (
           <Route path="/" element={<Index />} />
           <Route path="/bills" element={<Bills />} />
           <Route path="/transparency" element={<Transparency />} />
+          <Route path="/transparency/:id" element={<Transparency />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </BrowserRouter>

--- a/final-main/src/components/ChatInput.tsx
+++ b/final-main/src/components/ChatInput.tsx
@@ -6,10 +6,16 @@ import { Send, Loader2 } from "lucide-react";
 interface ChatInputProps {
   onSendMessage: (message: string) => void;
   loading: boolean;
+  mode: "describe" | "troubleshoot";
 }
 
-const ChatInput = ({ onSendMessage, loading }: ChatInputProps) => {
+const ChatInput = ({ onSendMessage, loading, mode }: ChatInputProps) => {
   const [message, setMessage] = useState("");
+
+  const placeholder =
+    mode === "describe"
+      ? "Ask about a bill, policy, or legislative change..."
+      : "Need help finding something? Ask for search tips...";
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -32,7 +38,7 @@ const ChatInput = ({ onSendMessage, loading }: ChatInputProps) => {
         value={message}
         onChange={(e) => setMessage(e.target.value)}
         onKeyDown={handleKeyDown}
-        placeholder="Ask about political topics, policies, governance..."
+        placeholder={placeholder}
         disabled={loading}
         className="min-h-[60px] max-h-[200px] resize-none"
         rows={2}

--- a/final-main/src/components/ChatMessage.tsx
+++ b/final-main/src/components/ChatMessage.tsx
@@ -1,4 +1,4 @@
-import { Bot, User, ExternalLink } from "lucide-react";
+import { Bot, User, ExternalLink, ShieldAlert } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 
@@ -12,9 +12,11 @@ interface ChatMessageProps {
   role: 'user' | 'assistant';
   content: string;
   citations?: Citation[];
+  isStreaming?: boolean;
+  guardrailWarnings?: string[];
 }
 
-const ChatMessage = ({ role, content, citations }: ChatMessageProps) => {
+const ChatMessage = ({ role, content, citations, isStreaming, guardrailWarnings }: ChatMessageProps) => {
   const isUser = role === 'user';
 
   // Extract inline citations from content (format: [Source: description])
@@ -48,6 +50,9 @@ const ChatMessage = ({ role, content, citations }: ChatMessageProps) => {
         }`}>
           <div className="prose prose-sm max-w-none dark:prose-invert whitespace-pre-wrap">
             {content}
+            {isStreaming && (
+              <span className="inline-flex w-2 h-4 ml-1 bg-current/60 animate-pulse rounded-sm align-middle" />
+            )}
           </div>
         </Card>
 
@@ -92,6 +97,13 @@ const ChatMessage = ({ role, content, citations }: ChatMessageProps) => {
                 )}
               </Badge>
             ))}
+          </div>
+        )}
+
+        {!isUser && guardrailWarnings && guardrailWarnings.length > 0 && (
+          <div className="flex items-center gap-2 text-xs text-amber-600 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-900/60 rounded-md px-3 py-2 mr-12">
+            <ShieldAlert className="h-3 w-3" />
+            <span>{guardrailWarnings.join(' · ')}</span>
           </div>
         )}
       </div>

--- a/final-main/src/components/chat/ChatInput.tsx
+++ b/final-main/src/components/chat/ChatInput.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+import { Send } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+type ChatInputProps = {
+  onSend: (message: string) => void;
+  disabled?: boolean;
+  mode: "describe" | "troubleshoot";
+};
+
+export const ChatInput = ({ onSend, disabled, mode }: ChatInputProps) => {
+  const [input, setInput] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (input.trim() && !disabled) {
+      onSend(input.trim());
+      setInput("");
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit(e);
+    }
+  };
+
+  const placeholder =
+    mode === "describe"
+      ? "Ask about a bill, policy, or legislative change..."
+      : "Need help finding something? Ask for search tips...";
+
+  return (
+    <form onSubmit={handleSubmit} className="relative">
+      <Textarea
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        disabled={disabled}
+        className="min-h-[60px] pr-12 resize-none shadow-soft"
+      />
+      <Button
+        type="submit"
+        size="icon"
+        disabled={!input.trim() || disabled}
+        className="absolute right-2 bottom-2 rounded-full shadow-medium"
+      >
+        <Send className="h-4 w-4" />
+      </Button>
+    </form>
+  );
+};

--- a/final-main/src/components/chat/ChatMessage.tsx
+++ b/final-main/src/components/chat/ChatMessage.tsx
@@ -1,0 +1,77 @@
+import { User, Bot, Link2, ShieldAlert } from "lucide-react";
+import type { OrchestratorResponse } from "@/types/orchestrator";
+
+type Message = {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  timestamp: Date;
+  isStreaming?: boolean;
+  citations?: OrchestratorResponse["answer"]["citations"];
+  guardrailWarnings?: string[];
+};
+
+type ChatMessageProps = {
+  message: Message;
+};
+
+export const ChatMessage = ({ message }: ChatMessageProps) => {
+  const isUser = message.role === "user";
+
+  return (
+    <div className={`flex gap-4 ${isUser ? "justify-end" : "justify-start"}`}>
+      {!isUser && (
+        <div className="flex-shrink-0 w-8 h-8 rounded-full bg-primary flex items-center justify-center shadow-soft">
+          <Bot className="h-4 w-4 text-primary-foreground" />
+        </div>
+      )}
+
+      <div className={`flex flex-col gap-2 max-w-[80%] ${isUser ? "items-end" : "items-start"}`}>
+        <div
+          className={`rounded-2xl px-4 py-3 shadow-soft ${
+            isUser
+              ? "bg-primary text-primary-foreground"
+              : "bg-card text-card-foreground border border-border"
+          }`}
+        >
+          <p className="text-sm leading-relaxed whitespace-pre-wrap">
+            {message.content}
+            {message.isStreaming && (
+              <span className="inline-block w-1 h-4 ml-1 bg-current animate-pulse" />
+            )}
+          </p>
+        </div>
+
+        {!isUser && !message.isStreaming && message.citations && (
+          <div className="flex flex-wrap gap-2 px-2">
+            {message.citations.map((citation) => (
+              <a
+                key={citation.url}
+                href={citation.url}
+                target="_blank"
+                rel="noreferrer"
+                className="text-xs text-primary flex items-center gap-1 hover:underline"
+              >
+                <Link2 className="h-3 w-3" />
+                {citation.label}
+              </a>
+            ))}
+          </div>
+        )}
+
+        {!isUser && message.guardrailWarnings && message.guardrailWarnings.length > 0 && (
+          <div className="flex items-center gap-2 px-2 text-xs text-amber-600">
+            <ShieldAlert className="h-3 w-3" />
+            <span>{message.guardrailWarnings.join(" · ")}</span>
+          </div>
+        )}
+      </div>
+
+      {isUser && (
+        <div className="flex-shrink-0 w-8 h-8 rounded-full bg-secondary flex items-center justify-center shadow-soft">
+          <User className="h-4 w-4 text-secondary-foreground" />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/final-main/src/components/chat/ModeSelector.tsx
+++ b/final-main/src/components/chat/ModeSelector.tsx
@@ -1,0 +1,32 @@
+import { MessageSquare, HelpCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type ModeSelectorProps = {
+  mode: "describe" | "troubleshoot";
+  onModeChange: (mode: "describe" | "troubleshoot") => void;
+};
+
+export const ModeSelector = ({ mode, onModeChange }: ModeSelectorProps) => {
+  return (
+    <div className="flex gap-2 p-1 bg-muted rounded-lg">
+      <Button
+        variant={mode === "describe" ? "default" : "ghost"}
+        size="sm"
+        onClick={() => onModeChange("describe")}
+        className="gap-2"
+      >
+        <MessageSquare className="h-4 w-4" />
+        Describe
+      </Button>
+      <Button
+        variant={mode === "troubleshoot" ? "default" : "ghost"}
+        size="sm"
+        onClick={() => onModeChange("troubleshoot")}
+        className="gap-2"
+      >
+        <HelpCircle className="h-4 w-4" />
+        Troubleshoot
+      </Button>
+    </div>
+  );
+};

--- a/final-main/src/components/policy/PolicyCard.tsx
+++ b/final-main/src/components/policy/PolicyCard.tsx
@@ -1,0 +1,95 @@
+import { useNavigate } from "react-router-dom";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { FileText, TrendingUp, Clock, MapPin } from "lucide-react";
+import type { PolicySearchHit } from "@/types/orchestrator";
+
+type PolicyCardProps = {
+  policy: PolicySearchHit;
+};
+
+export const PolicyCard = ({ policy }: PolicyCardProps) => {
+  const navigate = useNavigate();
+
+  const getConfidenceColor = (confidence: number) => {
+    if (confidence >= 90) return "text-success";
+    if (confidence >= 75) return "text-warning";
+    return "text-muted-foreground";
+  };
+
+  const fontClass = "font-modern";
+
+  return (
+    <Card className="shadow-soft hover:shadow-medium transition-all border-border">
+      <CardContent className="p-6">
+        <div className="flex items-start justify-between mb-4">
+          <div className="flex-1">
+            <div className="flex items-center gap-2 mb-2">
+              <FileText className="h-5 w-5 text-foreground" />
+              <h3 className={`text-lg font-semibold text-foreground ${fontClass}`}>
+                {policy.title}
+              </h3>
+            </div>
+
+            <div className="flex flex-wrap gap-2 mb-3">
+              <Badge variant="outline" className="gap-1">
+                <MapPin className="h-3 w-3" />
+                {policy.jurisdiction}
+              </Badge>
+              <Badge
+                variant={
+                  (policy.status ?? "").toLowerCase().includes("pass") ||
+                  (policy.status ?? "").toLowerCase().includes("became law")
+                    ? "default"
+                    : "secondary"
+                }
+              >
+                {policy.status ?? "Unknown"}
+              </Badge>
+            </div>
+
+            <div className="flex items-center gap-2 text-sm text-muted-foreground mb-4">
+              <Clock className="h-4 w-4" />
+              <span>{policy.latestAction ?? "No recent action"}</span>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 bg-muted px-3 py-1 rounded-full">
+            <TrendingUp className={`h-4 w-4 ${getConfidenceColor(policy.confidence)}`} />
+            <span className={`text-sm font-semibold ${getConfidenceColor(policy.confidence)}`}>
+              {policy.confidence}%
+            </span>
+          </div>
+        </div>
+
+        {policy.sections.length > 0 && (
+          <div className="space-y-2 mb-4">
+            <p className="text-sm font-medium text-foreground">Top matched sections:</p>
+            <ul className="space-y-1">
+              {policy.sections.map((section, idx) => (
+                <li
+                  key={section.id ?? `${policy.billId}-section-${idx}`}
+                  className="text-sm text-muted-foreground pl-4 relative before:content-['•'] before:absolute before:left-0"
+                >
+                  <span className="font-medium text-foreground">
+                    {section.heading ?? "Relevant excerpt"}
+                  </span>
+                  : {section.snippet}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <Button
+          onClick={() => navigate(`/transparency/${policy.billId}`)}
+          className="w-full"
+          variant="outline"
+        >
+          View DNA
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};

--- a/final-main/src/components/transparency/BlameView.tsx
+++ b/final-main/src/components/transparency/BlameView.tsx
@@ -1,0 +1,74 @@
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { User, FileEdit } from "lucide-react";
+import type { PolicyBlameEntry } from "@/types/orchestrator";
+
+type BlameViewProps = {
+  entries: PolicyBlameEntry[];
+};
+
+export const BlameView = ({ entries }: BlameViewProps) => {
+  if (entries.length === 0) {
+    return (
+      <div className="text-sm text-muted-foreground italic">
+        No amendment attributions were returned for this bill.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {entries.map((entry) => (
+        <Card key={entry.sectionId} className="border-border hover:border-primary/50 transition-colors">
+          <CardContent className="p-4">
+            <div className="flex items-start gap-3">
+              <div className="flex-shrink-0 w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center">
+                <User className="h-4 w-4 text-primary" />
+              </div>
+
+              <div className="flex-1 space-y-2">
+                <div className="flex items-center gap-2 flex-wrap">
+                  {entry.sectionId && (
+                    <Badge variant="outline" className="text-xs">
+                      {entry.sectionId}
+                    </Badge>
+                  )}
+                  {entry.heading && (
+                    <Badge variant="outline" className="text-xs">
+                      {entry.heading}
+                    </Badge>
+                  )}
+                </div>
+
+                {entry.summary && (
+                  <p className="text-sm text-foreground italic">"{entry.summary}"</p>
+                )}
+
+                <div className="flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
+                  {entry.author && (
+                    <div className="flex items-center gap-1">
+                      <FileEdit className="h-3 w-3" />
+                      <span>{entry.author}</span>
+                    </div>
+                  )}
+                  {entry.actionType && <span>{entry.actionType}</span>}
+                  {entry.actionDate && <span>{new Date(entry.actionDate).toLocaleDateString()}</span>}
+                  {entry.sourceUri && (
+                    <a
+                      href={entry.sourceUri}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-primary hover:underline"
+                    >
+                      Source
+                    </a>
+                  )}
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+};

--- a/final-main/src/components/transparency/HistoryPanel.tsx
+++ b/final-main/src/components/transparency/HistoryPanel.tsx
@@ -1,0 +1,71 @@
+import { Badge } from "@/components/ui/badge";
+import { FileText, Vote, Users, FileCheck } from "lucide-react";
+import type { PolicyActionEvent } from "@/types/orchestrator";
+
+type HistoryPanelProps = {
+  actions: PolicyActionEvent[];
+};
+
+const getIcon = (type: string) => {
+  const normalized = type.toLowerCase();
+  if (normalized.includes("vote")) return Vote;
+  if (normalized.includes("amend")) return FileCheck;
+  if (normalized.includes("committee")) return Users;
+  return FileText;
+};
+
+export const HistoryPanel = ({ actions }: HistoryPanelProps) => {
+  if (actions.length === 0) {
+    return (
+      <div className="text-sm text-muted-foreground italic">
+        No recent actions were returned for this bill.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {actions.map((event, idx) => {
+        const Icon = getIcon(event.type ?? "");
+        return (
+          <div
+            key={`${event.type}-${idx}-${event.date}`}
+            className="flex gap-3 p-3 rounded-lg bg-muted/50 border border-border hover:border-primary/50 transition-colors"
+          >
+            <div className="flex-shrink-0 w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center">
+              <Icon className="h-4 w-4 text-primary" />
+            </div>
+
+            <div className="flex-1 space-y-1">
+              <div className="flex items-center gap-2 flex-wrap">
+                <h4 className="text-sm font-medium text-foreground">
+                  {event.description ?? event.type ?? "Action"}
+                </h4>
+                {event.actor && (
+                  <Badge variant="outline" className="text-xs">
+                    {event.actor}
+                  </Badge>
+                )}
+              </div>
+              {event.date && (
+                <p className="text-xs text-muted-foreground">
+                  {new Date(event.date).toLocaleDateString()}
+                </p>
+              )}
+              {event.link && (
+                <a
+                  href={event.link}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-xs text-primary hover:underline"
+                >
+                  View on Congress.gov
+                </a>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/final-main/src/components/transparency/InfluenceOverlay.tsx
+++ b/final-main/src/components/transparency/InfluenceOverlay.tsx
@@ -1,0 +1,114 @@
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import type { InfluenceResult } from "@/types/orchestrator";
+
+type InfluenceOverlayProps = {
+  influence?: InfluenceResult;
+  mode: "lobbying" | "finance";
+};
+
+export const InfluenceOverlay = ({ influence, mode }: InfluenceOverlayProps) => {
+  const records = mode === "lobbying" ? influence?.lobbying ?? [] : influence?.finance ?? [];
+  const notes = influence?.metadata?.notes ?? [];
+  const searchTerms = influence?.metadata?.searchTerms ?? [];
+
+  const metadataBlock = (
+    <div className="space-y-1 text-xs text-muted-foreground">
+      {notes.length > 0 && (
+        <ul className="list-disc list-inside space-y-1">
+          {notes.map((note, idx) => (
+            <li key={idx}>{note}</li>
+          ))}
+        </ul>
+      )}
+      {searchTerms.length > 0 && (
+        <p>
+          Search terms: <span className="font-medium text-foreground">{searchTerms.join(", ")}</span>
+        </p>
+      )}
+    </div>
+  );
+
+  if (records.length === 0) {
+    return (
+      <div className="space-y-3">
+        {notes.length > 0 || searchTerms.length > 0 ? metadataBlock : null}
+        <div className="text-sm text-muted-foreground italic">
+          No {mode === "lobbying" ? "lobbying" : "finance"} records matched this bill in the selected APIs.
+        </div>
+      </div>
+    );
+  }
+
+  if (mode === "lobbying") {
+    return (
+      <div className="space-y-3">
+        {notes.length > 0 || searchTerms.length > 0 ? metadataBlock : null}
+        {records.map((entry) => (
+          <div
+            key={entry.id}
+            className="p-3 rounded-lg bg-muted/50 border border-border hover:border-primary/50 transition-colors"
+          >
+            <div className="flex items-center justify-between mb-2">
+              <span className="font-medium text-sm text-foreground">{entry.client}</span>
+              <Badge variant="outline" className="text-xs">
+                {entry.issue ?? "General issue"}
+              </Badge>
+            </div>
+            <p className="text-xs text-muted-foreground mb-2">
+              Registrant: {entry.registrant}
+            </p>
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <span>{entry.period ?? "Recent"}</span>
+              {entry.amount && <span>${entry.amount.toLocaleString()}</span>}
+            </div>
+            {entry.sourceUrl && (
+              <a
+                href={entry.sourceUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="text-xs text-primary hover:underline mt-2 inline-flex"
+              >
+                View filing
+              </a>
+            )}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {notes.length > 0 || searchTerms.length > 0 ? metadataBlock : null}
+      {records.map((entry) => (
+        <div
+          key={entry.candidateId}
+          className="p-3 rounded-lg bg-muted/50 border border-border hover:border-primary/50 transition-colors"
+        >
+          <div className="flex items-center justify-between mb-2">
+            <span className="font-medium text-sm text-foreground">{entry.committeeName}</span>
+            {entry.cycle && <Badge variant="outline" className="text-xs">Cycle {entry.cycle}</Badge>}
+          </div>
+          <div className="text-xs text-muted-foreground">
+            Total receipts: ${entry.totalReceipts?.toLocaleString() ?? "N/A"}
+          </div>
+          <Progress
+            value={Math.min(100, ((entry.totalReceipts ?? 0) / 10_000_000) * 100)}
+            className="h-1 mt-2"
+          />
+          {entry.sourceUrl && (
+            <a
+              href={entry.sourceUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="text-xs text-primary hover:underline mt-2 inline-flex"
+            >
+              View FEC detail
+            </a>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/final-main/src/components/transparency/PolicyChatPanel.tsx
+++ b/final-main/src/components/transparency/PolicyChatPanel.tsx
@@ -1,0 +1,159 @@
+import { useMemo, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { Send } from "lucide-react";
+
+import { ChatMessage } from "@/components/chat/ChatMessage";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { sendChat } from "@/lib/api";
+import type {
+  OrchestratorResponse,
+  PolicyFilters,
+  PolicyDNAResult,
+} from "@/types/orchestrator";
+
+type Message = {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  timestamp: Date;
+  isStreaming?: boolean;
+  citations?: OrchestratorResponse["answer"]["citations"];
+  guardrailWarnings?: string[];
+};
+
+type PolicyChatPanelProps = {
+  billId: string;
+  metadata?: PolicyDNAResult["metadata"];
+};
+
+export const PolicyChatPanel = ({ billId, metadata }: PolicyChatPanelProps) => {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("");
+
+  const contextualFilters = useMemo<PolicyFilters>(() => {
+    const keywords = [
+      metadata?.title,
+      metadata?.summary,
+      metadata?.billType && metadata?.billNumber
+        ? `${metadata.billType.toUpperCase()} ${metadata.billNumber}`
+        : undefined,
+    ]
+      .filter((value): value is string => Boolean(value && value.trim().length > 0))
+      .map((value) => value.trim());
+
+    return {
+      billId,
+      congress: metadata?.congress,
+      keywords,
+    };
+  }, [billId, metadata?.title, metadata?.summary, metadata?.billType, metadata?.billNumber, metadata?.congress]);
+
+  const chatMutation = useMutation({
+    mutationFn: async (input: { content: string; assistantId: string }) => {
+      const response = await sendChat(input.content, contextualFilters);
+      return { response, assistantId: input.assistantId };
+    },
+    onSuccess: ({ response, assistantId }) => {
+      setMessages((prev) =>
+        prev.map((message) =>
+          message.id === assistantId
+            ? {
+                ...message,
+                content: response.answer.answer,
+                citations: response.answer.citations,
+                guardrailWarnings: response.guardrail.warnings,
+                isStreaming: false,
+              }
+            : message
+        )
+      );
+    },
+    onError: (error, variables) => {
+      setMessages((prev) =>
+        prev.map((message) =>
+          message.id === variables.assistantId
+            ? {
+                ...message,
+                content:
+                  error instanceof Error
+                    ? `We couldn't reach the orchestrator: ${error.message}`
+                    : "We couldn't reach the orchestrator.",
+                isStreaming: false,
+              }
+            : message
+        )
+      );
+    },
+  });
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!input.trim() || chatMutation.isPending) return;
+
+    const trimmed = input.trim();
+    const userMessage: Message = {
+      id: `${Date.now()}-user`,
+      role: "user",
+      content: trimmed,
+      timestamp: new Date(),
+    };
+    setMessages((prev) => [...prev, userMessage]);
+
+    const assistantId = `${Date.now()}-assistant`;
+    const assistantMessage: Message = {
+      id: assistantId,
+      role: "assistant",
+      content: "",
+      timestamp: new Date(),
+      isStreaming: true,
+    };
+    setMessages((prev) => [...prev, assistantMessage]);
+
+    chatMutation.mutate({ content: trimmed, assistantId });
+    setInput("");
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      handleSubmit(event as unknown as React.FormEvent);
+    }
+  };
+
+  return (
+    <div className="bg-card rounded-xl border border-border p-6 shadow-medium space-y-4">
+      <div className="space-y-3 max-h-[360px] overflow-y-auto pr-2">
+        {messages.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Ask focused questions about this bill. We’ll keep the retrieval anchored to
+            {" "}
+            <span className="font-medium">{metadata?.title ?? billId}</span>.
+          </p>
+        ) : (
+          messages.map((message) => <ChatMessage key={message.id} message={message} />)
+        )}
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <Textarea
+          value={input}
+          onChange={(event) => setInput(event.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Ask how this policy changes over time or who funds it..."
+          disabled={chatMutation.isPending}
+          className="min-h-[80px] resize-none"
+        />
+        <div className="flex justify-end">
+          <Button
+            type="submit"
+            disabled={!input.trim() || chatMutation.isPending}
+            className="rounded-full"
+          >
+            <Send className="h-4 w-4 mr-2" /> Ask
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/final-main/src/components/transparency/VersionTimeline.tsx
+++ b/final-main/src/components/transparency/VersionTimeline.tsx
@@ -1,0 +1,90 @@
+import { Badge } from "@/components/ui/badge";
+import type { PolicyTimelineEntry } from "@/types/orchestrator";
+
+type VersionTimelineProps = {
+  versions: PolicyTimelineEntry[];
+  selectedVersion?: string;
+  onVersionSelect: (version: string) => void;
+};
+
+export const VersionTimeline = ({
+  versions,
+  selectedVersion,
+  onVersionSelect,
+}: VersionTimelineProps) => {
+  const getChangeColor = (changes: number) => {
+    if (changes === 0) return "bg-muted";
+    if (changes < 50) return "bg-success";
+    if (changes < 100) return "bg-warning";
+    return "bg-destructive";
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="relative">
+        {/* Timeline line */}
+        <div className="absolute left-4 top-0 bottom-0 w-0.5 bg-border" />
+
+        {/* Version items */}
+        <div className="space-y-6">
+          {versions.map((version, idx) => (
+            <div
+              key={version.versionId}
+              className="relative flex items-start gap-4 cursor-pointer group"
+              onClick={() => onVersionSelect(version.versionId)}
+            >
+              {/* Timeline dot */}
+              <div
+                className={`relative z-10 w-8 h-8 rounded-full flex items-center justify-center transition-all ${
+                  selectedVersion === version.versionId
+                    ? "bg-primary ring-4 ring-primary/20"
+                    : "bg-card border-2 border-border group-hover:border-primary"
+                }`}
+              >
+                <span className="text-xs font-semibold text-foreground">
+                  {idx + 1}
+                </span>
+              </div>
+
+              {/* Version info */}
+              <div
+                className={`flex-1 p-4 rounded-lg border transition-all ${
+                  selectedVersion === version.versionId
+                    ? "border-primary bg-primary/5"
+                    : "border-border bg-card/50 group-hover:border-primary/50"
+                }`}
+              >
+                <div className="flex items-center justify-between mb-2">
+                  <h3 className="font-semibold text-foreground">
+                    {version.label}
+                  </h3>
+                  {version.issuedOn && (
+                    <Badge variant="outline" className="text-xs">
+                      {new Date(version.issuedOn).toLocaleDateString()}
+                    </Badge>
+                  )}
+                </div>
+                <div className="flex items-center gap-3 text-sm">
+                  {version.changeSummary && (
+                    <div className="flex items-center gap-2">
+                      <div
+                        className={`h-2 w-12 rounded-full ${getChangeColor(
+                          (version.changeSummary.added ?? 0) +
+                            (version.changeSummary.removed ?? 0)
+                        )}`}
+                      />
+                      <span className="text-muted-foreground">
+                        +{version.changeSummary.added ?? 0} / -
+                        {version.changeSummary.removed ?? 0}
+                      </span>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/final-main/src/lib/api.ts
+++ b/final-main/src/lib/api.ts
@@ -1,0 +1,36 @@
+import {
+  OrchestratorResponse,
+  PolicyDetailResponse,
+  PolicyFilters,
+} from "@/types/orchestrator";
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8787";
+
+const parseResponse = async <T>(response: Response): Promise<T> => {
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || response.statusText);
+  }
+  return response.json() as Promise<T>;
+};
+
+export const sendChat = async (
+  message: string,
+  filters?: PolicyFilters
+): Promise<OrchestratorResponse> => {
+  const response = await fetch(`${API_BASE}/api/chat`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ message, filters }),
+  });
+  return parseResponse<OrchestratorResponse>(response);
+};
+
+export const fetchPolicyDetail = async (
+  billId: string
+): Promise<PolicyDetailResponse> => {
+  const response = await fetch(`${API_BASE}/api/policy/${encodeURIComponent(billId)}`);
+  return parseResponse<PolicyDetailResponse>(response);
+};

--- a/final-main/src/pages/Index.tsx
+++ b/final-main/src/pages/Index.tsx
@@ -1,148 +1,277 @@
-import { useState, useEffect, useRef } from "react";
-import { supabase } from "@/integrations/supabase/client";
-import { useToast } from "@/hooks/use-toast";
-import ChatMessage from "@/components/ChatMessage";
-import ChatInput from "@/components/ChatInput";
-import LegitimacyWidget from "@/components/LegitimacyWidget";
-import ConversationList from "@/components/ConversationList";
-import { ScrollArea } from "@/components/ui/scroll-area";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Brain } from "lucide-react";
 
-interface Message {
-  role: 'user' | 'assistant';
-  content: string;
-  id: string;
-}
+import ChatInput from "@/components/ChatInput";
+import ChatMessage from "@/components/ChatMessage";
+import ConversationList from "@/components/ConversationList";
+import LegitimacyWidget from "@/components/LegitimacyWidget";
+import { ModeSelector } from "@/components/chat/ModeSelector";
+import { PolicyCard } from "@/components/policy/PolicyCard";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { useToast } from "@/hooks/use-toast";
+import { sendChat } from "@/lib/api";
+import type { OrchestratorResponse, PolicySearchHit } from "@/types/orchestrator";
 
-interface Conversation {
+const STORAGE_KEY = "poliscope_conversations";
+
+const uuid = () =>
+  typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+type Message = {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  timestamp: string;
+  isStreaming?: boolean;
+  citations?: OrchestratorResponse["answer"]["citations"];
+  guardrailWarnings?: string[];
+  policies?: PolicySearchHit[];
+};
+
+type Conversation = {
   id: string;
   title: string;
   updated_at: string;
   messages: Message[];
-}
+  logs: string[];
+};
+
+const sortConversations = (conversations: Conversation[]) =>
+  [...conversations].sort(
+    (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+  );
 
 const Index = () => {
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [currentConversationId, setCurrentConversationId] = useState<string>();
   const [messages, setMessages] = useState<Message[]>([]);
+  const [logs, setLogs] = useState<string[]>([]);
+  const [mode, setMode] = useState<"describe" | "troubleshoot">("describe");
   const [sending, setSending] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const { toast } = useToast();
 
   useEffect(() => {
-    loadConversations();
+    if (typeof window === "undefined") return;
+    const saved = window.localStorage.getItem(STORAGE_KEY);
+    if (!saved) return;
+
+    try {
+      const parsed = JSON.parse(saved) as Conversation[];
+      const normalised = parsed.map((conversation) => ({
+        id: conversation.id ?? uuid(),
+        title: conversation.title ?? "New Conversation",
+        updated_at: conversation.updated_at ?? new Date().toISOString(),
+        messages: (conversation.messages ?? []).map((message) => ({
+          id: message.id ?? uuid(),
+          role: message.role === "assistant" ? "assistant" : "user",
+          content: message.content ?? "",
+          timestamp: message.timestamp ?? new Date().toISOString(),
+          citations: message.citations,
+          guardrailWarnings: message.guardrailWarnings,
+          policies: message.policies,
+        })),
+        logs: conversation.logs ?? [],
+      }));
+
+      const sorted = sortConversations(normalised);
+      setConversations(sorted);
+      if (sorted.length > 0) {
+        setCurrentConversationId(sorted[0].id);
+        setMessages(sorted[0].messages);
+        setLogs(sorted[0].logs);
+      }
+    } catch (error) {
+      console.error("Failed to parse stored conversations", error);
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
   }, []);
 
-  useEffect(() => {
-    if (currentConversationId) {
-      const conversation = conversations.find(c => c.id === currentConversationId);
-      if (conversation) {
-        setMessages(conversation.messages);
+  const persistConversations = (updater: (prev: Conversation[]) => Conversation[]) => {
+    setConversations((prev) => {
+      const next = sortConversations(updater(prev));
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
       }
+      return next;
+    });
+  };
+
+  useEffect(() => {
+    if (!currentConversationId) return;
+    const conversation = conversations.find((c) => c.id === currentConversationId);
+    if (conversation) {
+      setMessages(conversation.messages);
+      setLogs(conversation.logs);
     }
   }, [currentConversationId, conversations]);
+
+  useEffect(() => {
+    if (!currentConversationId && conversations.length > 0) {
+      setCurrentConversationId(conversations[0].id);
+    }
+  }, [conversations, currentConversationId]);
 
   useEffect(() => {
     scrollRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
-  const loadConversations = () => {
-    const saved = localStorage.getItem('poliscope_conversations');
-    if (saved) {
-      const parsed = JSON.parse(saved);
-      setConversations(parsed);
-      if (parsed.length > 0 && !currentConversationId) {
-        setCurrentConversationId(parsed[0].id);
-      }
-    }
-  };
-
-  const saveConversations = (convos: Conversation[]) => {
-    localStorage.setItem('poliscope_conversations', JSON.stringify(convos));
-    setConversations(convos);
-  };
-
   const createConversation = (): string => {
-    const newConversation: Conversation = {
-      id: crypto.randomUUID(),
-      title: 'New Conversation',
+    const conversation: Conversation = {
+      id: uuid(),
+      title: "New Conversation",
       updated_at: new Date().toISOString(),
       messages: [],
+      logs: [],
     };
-    const updated = [newConversation, ...conversations];
-    saveConversations(updated);
-    setCurrentConversationId(newConversation.id);
+
+    persistConversations((prev) => [conversation, ...prev]);
+    setCurrentConversationId(conversation.id);
     setMessages([]);
-    return newConversation.id;
+    setLogs([]);
+    return conversation.id;
   };
 
-  const updateConversation = (conversationId: string, newMessages: Message[]) => {
-    const updated = conversations.map(c => 
-      c.id === conversationId 
-        ? { 
-            ...c, 
-            messages: newMessages,
-            title: newMessages[0]?.content.slice(0, 50) || 'New Conversation',
-            updated_at: new Date().toISOString(),
-          }
-        : c
+  const updateConversation = (
+    conversationId: string,
+    transform: (conversation: Conversation) => Conversation
+  ) => {
+    persistConversations((prev) =>
+      prev.map((conversation) =>
+        conversation.id === conversationId ? transform(conversation) : conversation
+      )
     );
-    saveConversations(updated);
   };
 
-  const sendMessage = async (content: string) => {
-    let convId = currentConversationId;
-    if (!convId) {
-      convId = createConversation();
+  const sendMessage = async (input: string) => {
+    const content = input.trim();
+    if (!content) return;
+
+    let conversationId = currentConversationId;
+    if (!conversationId) {
+      conversationId = createConversation();
     }
 
+    if (!conversationId) return;
+
     setSending(true);
+
+    const userMessage: Message = {
+      id: uuid(),
+      role: "user",
+      content,
+      timestamp: new Date().toISOString(),
+    };
+
+    const withUser = [...messages, userMessage];
+    setMessages(withUser);
+    updateConversation(conversationId, (conversation) => ({
+      ...conversation,
+      messages: withUser,
+      title:
+        conversation.messages.length === 0
+          ? content.slice(0, 60) || "New Conversation"
+          : conversation.title,
+      updated_at: userMessage.timestamp,
+    }));
+
+    const assistantId = uuid();
+    const assistantPlaceholder: Message = {
+      id: assistantId,
+      role: "assistant",
+      content: "",
+      timestamp: new Date().toISOString(),
+      isStreaming: true,
+    };
+
+    const withAssistant = [...withUser, assistantPlaceholder];
+    setMessages(withAssistant);
+    updateConversation(conversationId, (conversation) => ({
+      ...conversation,
+      messages: withAssistant,
+      updated_at: assistantPlaceholder.timestamp,
+    }));
+
     try {
-      const userMessage: Message = {
-        role: 'user',
-        content,
-        id: crypto.randomUUID(),
-      };
+      const response = await sendChat(content);
 
-      const newMessages = [...messages, userMessage];
-      setMessages(newMessages);
-      updateConversation(convId!, newMessages);
+      setMessages((prev) => {
+        const updated = prev.map((message) =>
+          message.id === assistantId
+            ? {
+                ...message,
+                content: response.answer.answer,
+                citations: response.answer.citations,
+                guardrailWarnings: response.guardrail.warnings,
+                policies: response.policies,
+                isStreaming: false,
+                timestamp: new Date().toISOString(),
+              }
+            : message
+        );
 
-      const { data, error } = await supabase.functions.invoke('ai-chat', {
-        body: {
-          messages: newMessages.map(m => ({ role: m.role, content: m.content })),
-          conversationId: convId,
-        },
+        updateConversation(conversationId!, (conversation) => ({
+          ...conversation,
+          messages: updated,
+          logs: response.logs ?? [],
+          updated_at: new Date().toISOString(),
+        }));
+
+        setLogs(response.logs ?? []);
+        return updated;
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Failed to contact the orchestrator.";
+
+      toast({
+        title: "Chat error",
+        description: message,
+        variant: "destructive",
       });
 
-      if (error) throw error;
+      setMessages((prev) => {
+        const updated = prev.map((item) =>
+          item.id === assistantId
+            ? {
+                ...item,
+                content: `Sorry, something went wrong: ${message}`,
+                isStreaming: false,
+              }
+            : item
+        );
 
-      if (data?.content) {
-        const assistantMessage: Message = {
-          role: 'assistant',
-          content: data.content,
-          id: crypto.randomUUID(),
-        };
-        const finalMessages = [...newMessages, assistantMessage];
-        setMessages(finalMessages);
-        updateConversation(convId!, finalMessages);
-      }
-    } catch (error: any) {
-      toast({ 
-        title: "Error", 
-        description: error.message || "Failed to get response", 
-        variant: "destructive" 
+        updateConversation(conversationId!, (conversation) => ({
+          ...conversation,
+          messages: updated,
+          updated_at: new Date().toISOString(),
+        }));
+
+        return updated;
       });
     } finally {
       setSending(false);
     }
   };
 
+  const activeConversation = useMemo(
+    () => conversations.find((conversation) => conversation.id === currentConversationId),
+    [conversations, currentConversationId]
+  );
+
   return (
-    <div className="flex h-screen">
+    <div className="flex h-[calc(100vh-56px)]">
       <div className="w-80 hidden md:block">
         <ConversationList
-          conversations={conversations}
+          conversations={conversations.map(({ id, title, updated_at }) => ({
+            id,
+            title,
+            updated_at,
+          }))}
           currentConversationId={currentConversationId}
           onSelectConversation={setCurrentConversationId}
           onNewConversation={createConversation}
@@ -162,26 +291,26 @@ const Index = () => {
                   Welcome to PoliScope
                 </h1>
                 <p className="text-lg text-muted-foreground">
-                  AI-Powered Political Analysis & Policy Research
+                  AI-powered legislative intelligence with cited sourcing
                 </p>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-8">
                 <div className="p-4 rounded-lg bg-card border border-border hover:border-primary/50 transition-all">
                   <h3 className="font-semibold mb-2">Policy Analysis</h3>
                   <p className="text-sm text-muted-foreground">
-                    Get in-depth analysis of political policies and their impacts
+                    Summaries, comparisons, and change tracking for bills across jurisdictions
                   </p>
                 </div>
                 <div className="p-4 rounded-lg bg-card border border-border hover:border-primary/50 transition-all">
-                  <h3 className="font-semibold mb-2">Cited Sources</h3>
+                  <h3 className="font-semibold mb-2">Grounded Answers</h3>
                   <p className="text-sm text-muted-foreground">
-                    All insights backed by verifiable sources and data
+                    Each response is linked to verifiable citations from the orchestrator stack
                   </p>
                 </div>
                 <div className="p-4 rounded-lg bg-card border border-border hover:border-primary/50 transition-all">
-                  <h3 className="font-semibold mb-2">Balanced Views</h3>
+                  <h3 className="font-semibold mb-2">Policy DNA</h3>
                   <p className="text-sm text-muted-foreground">
-                    Objective analysis presenting multiple perspectives
+                    Jump into transparency mode to inspect authorship, influence, and version history
                   </p>
                 </div>
               </div>
@@ -190,22 +319,63 @@ const Index = () => {
         ) : (
           <ScrollArea className="flex-1 p-6">
             <div className="max-w-4xl mx-auto space-y-6">
-              {messages.map((msg) => (
-                <ChatMessage key={msg.id} role={msg.role} content={msg.content} />
+              {activeConversation && (
+                <div className="text-sm text-muted-foreground">
+                  Conversation updated {new Date(activeConversation.updated_at).toLocaleString()}
+                </div>
+              )}
+              {messages.map((message) => (
+                <div key={message.id} className="space-y-3">
+                  <ChatMessage
+                    role={message.role}
+                    content={message.content}
+                    citations={message.citations?.map((citation) => ({
+                      title: citation.label,
+                      url: citation.url,
+                    }))}
+                    isStreaming={message.isStreaming}
+                    guardrailWarnings={message.guardrailWarnings}
+                  />
+                  {message.role === "assistant" &&
+                    !message.isStreaming &&
+                    message.policies &&
+                    message.policies.length > 0 && (
+                      <div className="grid gap-4">
+                        {message.policies.map((policy) => (
+                          <PolicyCard key={`${message.id}-${policy.billId}`} policy={policy} />
+                        ))}
+                      </div>
+                    )}
+                </div>
               ))}
+              {logs.length > 0 && (
+                <div className="rounded-lg border border-dashed border-border p-4 text-xs text-muted-foreground space-y-1">
+                  <p className="font-medium text-foreground">Orchestrator log</p>
+                  {logs.map((entry, index) => (
+                    <p key={index}>{entry}</p>
+                  ))}
+                </div>
+              )}
               <div ref={scrollRef} />
             </div>
           </ScrollArea>
         )}
 
-<div className="border-t p-4 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-  <div className="max-w-4xl mx-auto grid gap-3">
-    <div className="text-sm font-semibold">Search Legitimacy (Describe mode)</div>
-    <LegitimacyWidget />
-    <ChatInput onSendMessage={sendMessage} loading={sending} />
-  </div>
-</div>
-
+        <div className="border-t p-4 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+          <div className="max-w-4xl mx-auto space-y-4">
+            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+              <div className="space-y-1">
+                <div className="text-sm font-semibold">Search Legitimacy (Describe mode)</div>
+                <p className="text-xs text-muted-foreground">
+                  Evaluate a claim before sending it to the assistant for further analysis.
+                </p>
+              </div>
+              <ModeSelector mode={mode} onModeChange={setMode} />
+            </div>
+            <LegitimacyWidget />
+            <ChatInput onSendMessage={sendMessage} loading={sending} mode={mode} />
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/final-main/src/pages/Transparency.tsx
+++ b/final-main/src/pages/Transparency.tsx
@@ -1,46 +1,179 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { ScrollArea } from '@/components/ui/scroll-area';
+import { useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { ArrowLeft, DollarSign, FileText, GitBranch, Users } from "lucide-react";
 
-export default function Transparency() {
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { BlameView } from "@/components/transparency/BlameView";
+import { HistoryPanel } from "@/components/transparency/HistoryPanel";
+import { InfluenceOverlay } from "@/components/transparency/InfluenceOverlay";
+import { PolicyChatPanel } from "@/components/transparency/PolicyChatPanel";
+import { VersionTimeline } from "@/components/transparency/VersionTimeline";
+import { fetchPolicyDetail } from "@/lib/api";
+
+const Transparency = () => {
+  const { id } = useParams<{ id?: string }>();
+  const navigate = useNavigate();
+  const billId = id ?? "";
+  const [selectedVersion, setSelectedVersion] = useState<string | undefined>(undefined);
+
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ["policy-detail", billId],
+    queryFn: () => fetchPolicyDetail(billId),
+    enabled: Boolean(billId),
+  });
+
+  const timeline = data?.dna.timeline ?? [];
+  const blame = data?.dna.blame ?? [];
+  const actions = data?.dna.actions ?? [];
+  const metadata = data?.dna.metadata;
+  const influence = data?.influence;
+
   return (
     <div className="flex flex-col h-[calc(100vh-56px)]">
       <ScrollArea className="flex-1">
-        <div className="max-w-6xl mx-auto p-4 space-y-4">
-          <Card>
-            <CardHeader><CardTitle>Version Timeline</CardTitle></CardHeader>
-            <CardContent>
-              <div className="text-sm text-muted-foreground">
-                v1 → v5 (Demo) — Diff heatmap showing clause changes across versions.
+        <div className="max-w-6xl mx-auto p-4 space-y-6">
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => navigate("/")}
+                className="rounded-full"
+                aria-label="Back to chat"
+              >
+                <ArrowLeft className="h-5 w-5" />
+              </Button>
+              <div>
+                <h1 className="text-2xl font-semibold leading-tight">
+                  {metadata?.title ?? (billId ? `Policy ${billId}` : "Transparency Graph")}
+                </h1>
+                <p className="text-sm text-muted-foreground">
+                  Legislative DNA, authorship, and influence mapping
+                </p>
+                {metadata?.sponsor?.name && (
+                  <p className="text-xs text-muted-foreground">
+                    Sponsor: {metadata.sponsor.name}
+                    {metadata.sponsor.party && ` (${metadata.sponsor.party}${metadata.sponsor.state ? ` · ${metadata.sponsor.state}` : ""})`}
+                  </p>
+                )}
               </div>
-            </CardContent>
-          </Card>
+            </div>
+          </div>
 
-          <Card>
-            <CardHeader><CardTitle>Blame View</CardTitle></CardHeader>
-            <CardContent>
-              <ul className="list-disc pl-6 text-sm">
-                <li>§2(b) inserted by House Committee on Oversight (Amendment A001)</li>
-                <li>§4 revised by Senate Rules Committee</li>
-                <li>Link to sponsors & votes (demo)</li>
-              </ul>
-            </CardContent>
-          </Card>
+          {!billId ? (
+            <Card>
+              <CardHeader>
+                <CardTitle>Select a policy</CardTitle>
+              </CardHeader>
+              <CardContent className="text-sm text-muted-foreground space-y-3">
+                <p>
+                  Choose a bill from the chat recommendations to explore its version history, clause authorship,
+                  and influence data.
+                </p>
+                <p>
+                  Once selected, this page will surface live policy DNA powered by the orchestrator APIs.
+                </p>
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="space-y-6">
+              {isLoading && (
+                <Card>
+                  <CardContent className="py-12 text-center text-sm text-muted-foreground">
+                    Loading transparency data…
+                  </CardContent>
+                </Card>
+              )}
 
-          <Card>
-            <CardHeader><CardTitle>Influence Overlay</CardTitle></CardHeader>
-            <CardContent className="text-sm">
-              Related lobbying reports (LD-1/LD-2) by issue code, finance signals for sponsors (demo). Filters by period/industry.
-            </CardContent>
-          </Card>
+              {isError && (
+                <Card>
+                  <CardContent className="py-12 text-center text-sm text-destructive">
+                    {(error as Error)?.message ?? "Unable to load policy detail."}
+                  </CardContent>
+                </Card>
+              )}
 
-          <Card>
-            <CardHeader><CardTitle>Commitments & History</CardTitle></CardHeader>
-            <CardContent className="text-sm">
-              Actions, amendments, committee reports, votes, executive actions; links to sources. (Demo)
-            </CardContent>
-          </Card>
+              {!isLoading && !isError && data && (
+                <div className="grid lg:grid-cols-3 gap-6">
+                  <div className="lg:col-span-2 space-y-6">
+                    <Card>
+                      <CardHeader className="flex flex-row items-center gap-3">
+                        <GitBranch className="h-5 w-5 text-primary" />
+                        <CardTitle>Version Timeline</CardTitle>
+                      </CardHeader>
+                      <CardContent>
+                        <VersionTimeline
+                          versions={timeline}
+                          selectedVersion={selectedVersion ?? timeline[0]?.versionId}
+                          onVersionSelect={setSelectedVersion}
+                        />
+                      </CardContent>
+                    </Card>
+
+                    <Card>
+                      <CardHeader className="flex flex-row items-center gap-3">
+                        <FileText className="h-5 w-5 text-primary" />
+                        <CardTitle>Clause Attribution</CardTitle>
+                      </CardHeader>
+                      <CardContent>
+                        <BlameView entries={blame} />
+                      </CardContent>
+                    </Card>
+                  </div>
+
+                  <div className="space-y-6">
+                    <PolicyChatPanel billId={billId} metadata={metadata} />
+
+                    <Card>
+                      <CardHeader>
+                        <CardTitle>Influence Overlay</CardTitle>
+                      </CardHeader>
+                      <CardContent>
+                        <Tabs defaultValue="lobbying" className="w-full">
+                          <TabsList className="grid grid-cols-2 w-full mb-4">
+                            <TabsTrigger value="lobbying" className="gap-2">
+                              <DollarSign className="h-4 w-4" /> Lobbying
+                            </TabsTrigger>
+                            <TabsTrigger value="finance" className="gap-2">
+                              <Users className="h-4 w-4" /> Finance
+                            </TabsTrigger>
+                          </TabsList>
+                          <TabsContent value="lobbying">
+                            <InfluenceOverlay influence={influence} mode="lobbying" />
+                          </TabsContent>
+                          <TabsContent value="finance">
+                            <InfluenceOverlay influence={influence} mode="finance" />
+                          </TabsContent>
+                        </Tabs>
+                      </CardContent>
+                    </Card>
+
+                    <Card>
+                      <CardHeader>
+                        <CardTitle>Commitments &amp; History</CardTitle>
+                      </CardHeader>
+                      <CardContent>
+                        <HistoryPanel actions={actions} />
+                      </CardContent>
+                    </Card>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
         </div>
       </ScrollArea>
     </div>
   );
-}
+};
+
+export default Transparency;

--- a/final-main/src/types/orchestrator.ts
+++ b/final-main/src/types/orchestrator.ts
@@ -1,0 +1,148 @@
+export type PolicyFilters = {
+  jurisdiction?: "federal" | "state";
+  congress?: number;
+  state?: string;
+  dateRange?: {
+    from?: string;
+    to?: string;
+  };
+  billId?: string;
+  keywords?: string[];
+};
+
+export type PolicySectionHit = {
+  id: string;
+  heading?: string;
+  snippet: string;
+  score: number;
+  sourceUri?: string;
+};
+
+export type PolicySearchHit = {
+  billId: string;
+  congress: number;
+  billType: string;
+  billNumber: string;
+  title: string;
+  status: string;
+  latestAction?: string;
+  summary?: string;
+  jurisdiction: "federal" | "state";
+  sections: PolicySectionHit[];
+  confidence: number;
+  sponsor?: {
+    name: string;
+    party?: string;
+    state?: string;
+  };
+};
+
+export type PolicyTimelineEntry = {
+  versionId: string;
+  label: string;
+  issuedOn?: string;
+  changeSummary?: {
+    added: number;
+    removed: number;
+    modified: number;
+  };
+  sourceUri?: string;
+};
+
+export type PolicyBlameEntry = {
+  sectionId: string;
+  heading?: string;
+  author?: string;
+  actionType?: string;
+  actionDate?: string;
+  summary?: string;
+  sourceUri?: string;
+};
+
+export type PolicyActionEvent = {
+  type: string;
+  date?: string;
+  actor?: string;
+  description?: string;
+  link?: string;
+};
+
+export type PolicyDNAResult = {
+  billId: string;
+  timeline: PolicyTimelineEntry[];
+  blame: PolicyBlameEntry[];
+  actions: PolicyActionEvent[];
+  metadata?: {
+    title?: string;
+    summary?: string;
+    sponsor?: {
+      name?: string;
+      party?: string;
+      state?: string;
+    };
+    congress?: number;
+    billType?: string;
+    billNumber?: string;
+  };
+};
+
+export type LobbyingRecord = {
+  id: string;
+  client: string;
+  registrant: string;
+  amount?: number;
+  issue?: string;
+  period?: string;
+  sourceUrl?: string;
+  relatedBills?: string[];
+  matchedTerms?: string[];
+};
+
+export type FinanceRecord = {
+  committeeName: string;
+  candidateId: string;
+  totalReceipts?: number;
+  cycle?: number;
+  sourceUrl?: string;
+};
+
+export type InfluenceResult = {
+  lobbying: LobbyingRecord[];
+  finance: FinanceRecord[];
+  metadata?: {
+    notes?: string[];
+    links?: Record<string, string>;
+    searchTerms?: string[];
+  };
+};
+
+export type GroundedAnswer = {
+  answer: string;
+  citations: {
+    label: string;
+    url: string;
+  }[];
+  disclaimers?: string[];
+};
+
+export type GuardrailFinding = {
+  ok: boolean;
+  warnings: string[];
+};
+
+export type OrchestratorResponse = {
+  query: string;
+  filters?: PolicyFilters;
+  policies: PolicySearchHit[];
+  dna?: PolicyDNAResult;
+  influence?: InfluenceResult;
+  answer: GroundedAnswer;
+  guardrail: GuardrailFinding;
+  logs: string[];
+};
+
+export type PolicyDetailResponse = {
+  billId: string;
+  dna: PolicyDNAResult;
+  influence: InfluenceResult;
+};


### PR DESCRIPTION
## Summary
- migrate the orchestrator-powered chat flow into the refreshed landing page with conversation persistence, policy cards, and logging
- port the transparency DNA components, orchestrator API client, and types so the new UI can render live bill insights
- enhance shared chat UI pieces to support mode-aware prompts, streaming state, guardrail warnings, and citations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e17fe279008332a7f143533b975d7d