### PR TITLE
Refresh UI to match VS design

### DIFF
--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -1,4 +1,6 @@
 import { User, Bot, Link2, ShieldAlert } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
 import type { OrchestratorResponse } from "@/types/orchestrator";
 
 type Message = {
@@ -18,58 +20,82 @@ type ChatMessageProps = {
 export const ChatMessage = ({ message }: ChatMessageProps) => {
   const isUser = message.role === "user";
 
+  const timestampLabel = message.timestamp.toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
   return (
-    <div className={`flex gap-4 ${isUser ? "justify-end" : "justify-start"}`}>
+    <div
+      className={cn(
+        "flex gap-4 animate-fade-up",
+        isUser ? "justify-end" : "justify-start"
+      )}
+    >
       {!isUser && (
-        <div className="flex-shrink-0 w-8 h-8 rounded-full bg-primary flex items-center justify-center shadow-soft">
-          <Bot className="h-4 w-4 text-primary-foreground" />
+        <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg gradient-primary shadow-glow">
+          <Bot className="h-5 w-5 text-primary-foreground" />
         </div>
       )}
 
-      <div className={`flex flex-col gap-2 max-w-[80%] ${isUser ? "items-end" : "items-start"}`}>
-        <div
-          className={`rounded-2xl px-4 py-3 shadow-soft ${
-            isUser
-              ? "bg-primary text-primary-foreground"
-              : "bg-card text-card-foreground border border-border"
-          }`}
-        >
+      <Card
+        className={cn(
+          "max-w-[80%] overflow-hidden border transition-all",
+          isUser
+            ? "border-none bg-gradient-primary text-primary-foreground shadow-glow"
+            : "border-card-border bg-card shadow-lg"
+        )}
+      >
+        <div className="space-y-3 p-4">
+          <div
+            className={cn(
+              "flex items-center gap-2 text-xs",
+              isUser ? "justify-end text-primary-foreground/80" : "text-muted-foreground"
+            )}
+          >
+            <span>{isUser ? "You" : "PolyScope AI"}</span>
+            <span className="hidden sm:inline">•</span>
+            <span className="font-mono text-[0.7rem] sm:text-[0.75rem]">
+              {timestampLabel}
+            </span>
+          </div>
+
           <p className="text-sm leading-relaxed whitespace-pre-wrap">
             {message.content}
             {message.isStreaming && (
-              <span className="inline-block w-1 h-4 ml-1 bg-current animate-pulse" />
+              <span className="ml-1 inline-block h-4 w-1 animate-pulse bg-current align-middle" />
             )}
           </p>
+
+          {!isUser && !message.isStreaming && message.citations && message.citations.length > 0 && (
+            <div className="flex flex-wrap gap-2 border-t border-border/70 pt-3">
+              {message.citations.map((citation) => (
+                <a
+                  key={citation.url}
+                  href={citation.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+                >
+                  <Link2 className="h-3 w-3" />
+                  {citation.label}
+                </a>
+              ))}
+            </div>
+          )}
+
+          {!isUser && message.guardrailWarnings && message.guardrailWarnings.length > 0 && (
+            <div className="flex items-center gap-2 rounded-md border border-warning/30 bg-warning/10 p-3 text-xs text-warning">
+              <ShieldAlert className="h-3 w-3" />
+              <span className="font-medium">{message.guardrailWarnings.join(" · ")}</span>
+            </div>
+          )}
         </div>
-
-        {!isUser && !message.isStreaming && message.citations && (
-          <div className="flex flex-wrap gap-2 px-2">
-            {message.citations.map((citation) => (
-              <a
-                key={citation.url}
-                href={citation.url}
-                target="_blank"
-                rel="noreferrer"
-                className="text-xs text-primary flex items-center gap-1 hover:underline"
-              >
-                <Link2 className="h-3 w-3" />
-                {citation.label}
-              </a>
-            ))}
-          </div>
-        )}
-
-        {!isUser && message.guardrailWarnings && message.guardrailWarnings.length > 0 && (
-          <div className="flex items-center gap-2 px-2 text-xs text-amber-600">
-            <ShieldAlert className="h-3 w-3" />
-            <span>{message.guardrailWarnings.join(" · ")}</span>
-          </div>
-        )}
-      </div>
+      </Card>
 
       {isUser && (
-        <div className="flex-shrink-0 w-8 h-8 rounded-full bg-secondary flex items-center justify-center shadow-soft">
-          <User className="h-4 w-4 text-secondary-foreground" />
+        <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-secondary shadow-md">
+          <User className="h-5 w-5 text-secondary-foreground" />
         </div>
       )}
     </div>

--- a/src/components/chat/ModeSelector.tsx
+++ b/src/components/chat/ModeSelector.tsx
@@ -1,5 +1,6 @@
 import { MessageSquare, HelpCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 type ModeSelectorProps = {
   mode: "describe" | "troubleshoot";
@@ -7,22 +8,37 @@ type ModeSelectorProps = {
 };
 
 export const ModeSelector = ({ mode, onModeChange }: ModeSelectorProps) => {
+  const baseClasses =
+    "rounded-full px-4 text-xs font-semibold transition-all sm:text-sm";
+
   return (
-    <div className="flex gap-2 p-1 bg-muted rounded-lg">
+    <div className="flex items-center gap-1 rounded-full border border-border bg-card/80 p-1 shadow-sm backdrop-blur">
       <Button
-        variant={mode === "describe" ? "default" : "ghost"}
+        variant="ghost"
         size="sm"
         onClick={() => onModeChange("describe")}
-        className="gap-2"
+        className={cn(
+          baseClasses,
+          "gap-2",
+          mode === "describe"
+            ? "bg-gradient-primary text-primary-foreground shadow-glow hover:text-primary-foreground"
+            : "text-muted-foreground hover:text-foreground"
+        )}
       >
         <MessageSquare className="h-4 w-4" />
         Describe
       </Button>
       <Button
-        variant={mode === "troubleshoot" ? "default" : "ghost"}
+        variant="ghost"
         size="sm"
         onClick={() => onModeChange("troubleshoot")}
-        className="gap-2"
+        className={cn(
+          baseClasses,
+          "gap-2",
+          mode === "troubleshoot"
+            ? "bg-gradient-primary text-primary-foreground shadow-glow hover:text-primary-foreground"
+            : "text-muted-foreground hover:text-foreground"
+        )}
       >
         <HelpCircle className="h-4 w-4" />
         Troubleshoot

--- a/src/components/policy/PolicyCard.tsx
+++ b/src/components/policy/PolicyCard.tsx
@@ -2,7 +2,7 @@ import { useNavigate } from "react-router-dom";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { FileText, TrendingUp, Clock, MapPin } from "lucide-react";
+import { FileText, TrendingUp, MapPin, Clock } from "lucide-react";
 import type { PolicySearchHit } from "@/types/orchestrator";
 
 type PolicyCardProps = {
@@ -18,64 +18,76 @@ export const PolicyCard = ({ policy }: PolicyCardProps) => {
     return "text-muted-foreground";
   };
 
+  const getStatusClasses = (status: string | undefined) => {
+    const normalized = (status ?? "").toLowerCase();
+
+    if (normalized.includes("pass") || normalized.includes("law")) {
+      return "bg-chart-2/10 text-chart-2 border-chart-2/20";
+    }
+
+    if (normalized.includes("committee") || normalized.includes("pending")) {
+      return "bg-warning/10 text-warning border-warning/20";
+    }
+
+    if (normalized.includes("active") || normalized.includes("progress")) {
+      return "bg-success/10 text-success border-success/20";
+    }
+
+    return "bg-muted text-muted-foreground border-border/60";
+  };
+
   const fontClass = "font-modern";
 
   return (
-    <Card className="shadow-soft hover:shadow-medium transition-all border-border">
-      <CardContent className="p-6">
-        <div className="flex items-start justify-between mb-4">
+    <Card className="glass border-card-border transition-all hover:shadow-glow">
+      <CardContent className="space-y-5 p-6">
+        <div className="flex items-start justify-between gap-4">
           <div className="flex-1">
-            <div className="flex items-center gap-2 mb-2">
-              <FileText className="h-5 w-5 text-foreground" />
-              <h3 className={`text-lg font-semibold text-foreground ${fontClass}`}>
-                {policy.title}
-              </h3>
-            </div>
-
-            <div className="flex flex-wrap gap-2 mb-3">
-              <Badge variant="outline" className="gap-1">
+            <div className="mb-2 flex flex-wrap items-center gap-2">
+              <Badge variant="outline" className="font-mono text-xs">
+                {policy.billId}
+              </Badge>
+              <Badge variant="outline" className="gap-1 text-xs">
                 <MapPin className="h-3 w-3" />
                 {policy.jurisdiction}
               </Badge>
-              <Badge
-                variant={
-                  (policy.status ?? "").toLowerCase().includes("pass") ||
-                  (policy.status ?? "").toLowerCase().includes("became law")
-                    ? "default"
-                    : "secondary"
-                }
-              >
-                {policy.status ?? "Unknown"}
+              <Badge className={getStatusClasses(policy.status)} variant={"outline"}>
+                {(policy.status ?? "Unknown").replace(/\b\w/g, (char) => char.toUpperCase())}
               </Badge>
             </div>
-
-            <div className="flex items-center gap-2 text-sm text-muted-foreground mb-4">
+            <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+              <FileText className="h-5 w-5 text-primary" />
+              <h3 className={`text-lg ${fontClass}`}>{policy.title}</h3>
+            </div>
+            <div className="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
               <Clock className="h-4 w-4" />
               <span>{policy.latestAction ?? "No recent action"}</span>
             </div>
           </div>
-
-          <div className="flex items-center gap-2 bg-muted px-3 py-1 rounded-full">
-            <TrendingUp className={`h-4 w-4 ${getConfidenceColor(policy.confidence)}`} />
-            <span className={`text-sm font-semibold ${getConfidenceColor(policy.confidence)}`}>
-              {policy.confidence}%
-            </span>
+          <div className="flex flex-col items-end gap-1 rounded-full bg-muted px-3 py-2 text-right">
+            <span className="text-xs font-medium text-muted-foreground">Confidence</span>
+            <div className="flex items-center gap-2">
+              <TrendingUp className={`h-4 w-4 ${getConfidenceColor(policy.confidence)}`} />
+              <span className={`text-sm font-semibold ${getConfidenceColor(policy.confidence)}`}>
+                {policy.confidence}%
+              </span>
+            </div>
           </div>
         </div>
 
         {policy.sections.length > 0 && (
-          <div className="space-y-2 mb-4">
-            <p className="text-sm font-medium text-foreground">Top matched sections:</p>
-            <ul className="space-y-1">
+          <div className="space-y-3">
+            <p className="text-sm font-medium text-foreground">Top matched sections</p>
+            <ul className="space-y-2">
               {policy.sections.map((section, idx) => (
                 <li
                   key={section.id ?? `${policy.billId}-section-${idx}`}
-                  className="text-sm text-muted-foreground pl-4 relative before:content-['•'] before:absolute before:left-0"
+                  className="relative flex flex-col gap-1 rounded-lg border border-dashed border-border/60 bg-muted/40 p-3 text-sm text-muted-foreground"
                 >
                   <span className="font-medium text-foreground">
                     {section.heading ?? "Relevant excerpt"}
                   </span>
-                  : {section.snippet}
+                  <span>{section.snippet}</span>
                 </li>
               ))}
             </ul>
@@ -84,10 +96,9 @@ export const PolicyCard = ({ policy }: PolicyCardProps) => {
 
         <Button
           onClick={() => navigate(`/transparency/${policy.billId}`)}
-          className="w-full"
-          variant="outline"
+          className="w-full gradient-primary text-primary-foreground shadow-glow transition-all hover:shadow-xl"
         >
-          View DNA
+          View Transparency Graph
         </Button>
       </CardContent>
     </Card>

--- a/src/index.css
+++ b/src/index.css
@@ -164,6 +164,18 @@
   h6 {
     @apply font-semibold tracking-tight;
   }
+
+  h1 {
+    @apply text-4xl md:text-5xl lg:text-6xl;
+  }
+
+  h2 {
+    @apply text-3xl md:text-4xl;
+  }
+
+  h3 {
+    @apply text-2xl md:text-3xl;
+  }
 }
 
 @layer utilities {
@@ -200,5 +212,11 @@
 
   .text-balance {
     text-wrap: balance;
+  }
+
+  .gradient-text {
+    background: var(--gradient-primary);
+    -webkit-background-clip: text;
+    color: transparent;
   }
 }

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -53,8 +53,8 @@ const techStack = [
 
 const About = () => (
   <div className="min-h-screen bg-background">
-    <header className="sticky top-0 z-50 border-b border-border bg-card/95 backdrop-blur-sm">
-      <div className="container mx-auto flex items-center gap-4 px-4 py-4">
+    <header className="sticky top-0 z-50 border-b border-border bg-card/95 shadow-sm backdrop-blur-sm">
+      <div className="container mx-auto flex max-w-5xl items-center gap-4 px-4 py-4">
         <Link to="/">
           <Button variant="ghost" size="sm" className="gap-2">
             <ArrowLeft className="h-4 w-4" />
@@ -62,14 +62,14 @@ const About = () => (
           </Button>
         </Link>
         <div>
-          <h1 className="text-2xl font-bold">About PolyScope</h1>
+          <h1 className="gradient-text text-2xl font-bold">About PolyScope</h1>
           <p className="text-sm text-muted-foreground">Built with modern web technologies</p>
         </div>
       </div>
     </header>
 
-    <main className="container mx-auto max-w-6xl px-4 py-8">
-      <Card className="glass border-card-border p-8 shadow-lg">
+    <main className="container mx-auto max-w-5xl px-4 py-8">
+      <Card className="mb-8 glass border-card-border p-8 shadow-lg">
         <h2 className="mb-4 text-3xl font-bold">Technology Stack</h2>
         <p className="leading-relaxed text-muted-foreground">
           PolyScope is built using cutting-edge web technologies to deliver a fast, reliable, and scalable policy transparency
@@ -77,7 +77,7 @@ const About = () => (
         </p>
       </Card>
 
-      <div className="mt-8 grid grid-cols-1 gap-6 md:grid-cols-2">
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
         {techStack.map((section) => (
           <Card key={section.category} className="glass border-card-border p-6 transition-all hover:shadow-glow">
             <div className="mb-6 flex items-center gap-3">
@@ -96,7 +96,7 @@ const About = () => (
         ))}
       </div>
 
-      <Card className="glass border-card-border p-8 shadow-lg">
+      <Card className="mt-8 glass border-card-border p-8 shadow-lg">
         <h3 className="mb-4 text-2xl font-bold">Why These Technologies?</h3>
         <div className="space-y-4 text-muted-foreground">
           <p>

--- a/src/pages/DNAPage.tsx
+++ b/src/pages/DNAPage.tsx
@@ -9,22 +9,29 @@ const DNAPage = () => {
 
   return (
     <div className="min-h-screen bg-background">
-      <header className="sticky top-0 z-50 border-b border-border bg-card/95 backdrop-blur-sm">
-        <div className="container mx-auto flex items-center gap-4 px-4 py-4">
-          <Link to="/">
-            <Button variant="ghost" size="sm" className="gap-2">
-              <ArrowLeft className="h-4 w-4" />
-              Back to Chat
-            </Button>
-          </Link>
-          <div className="flex items-center gap-3">
-            <h1 className="text-lg font-bold">Policy DNA Analysis</h1>
-            {billId && <Badge variant="outline">Bill {billId}</Badge>}
+      <header className="sticky top-0 z-50 border-b border-border bg-card/95 shadow-sm backdrop-blur-sm">
+        <div className="container mx-auto max-w-5xl px-4 py-4">
+          <div className="flex flex-wrap items-center gap-4">
+            <Link to="/">
+              <Button variant="ghost" size="sm" className="gap-2">
+                <ArrowLeft className="h-4 w-4" />
+                Back to Chat
+              </Button>
+            </Link>
+            <div className="hidden h-6 w-px bg-border sm:block" />
+            <div className="flex flex-wrap items-center gap-3">
+              <h1 className="text-lg font-bold">Policy DNA Analysis</h1>
+              {billId && (
+                <Badge variant="outline" className="font-mono">
+                  Bill {billId}
+                </Badge>
+              )}
+            </div>
           </div>
         </div>
       </header>
 
-      <main className="container mx-auto px-4 py-8">
+      <main className="container mx-auto max-w-5xl px-4 py-8">
         <PolicyDNA />
       </main>
     </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -151,18 +151,18 @@ const Index = () => {
 
   return (
     <div className="flex h-screen flex-col bg-background">
-      <header className="sticky top-0 z-50 border-b border-border bg-card/95 backdrop-blur-sm">
-        <div className="container mx-auto flex items-center justify-between gap-6 px-4 py-4">
+      <header className="sticky top-0 z-50 border-b border-border bg-card/95 shadow-sm backdrop-blur-sm">
+        <div className="container mx-auto flex max-w-5xl flex-wrap items-center justify-between gap-4 px-4 py-3">
           <div className="flex items-center gap-3">
             <div className="flex h-10 w-10 items-center justify-center rounded-lg gradient-primary shadow-glow">
               <Bot className="h-6 w-6 text-primary-foreground" />
             </div>
             <div>
-              <h1 className="text-lg font-bold tracking-tight">PolyScope</h1>
-              <p className="text-xs text-muted-foreground">AI-Powered Policy Intelligence</p>
+              <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">PolyScope</p>
+              <h1 className="text-lg font-bold tracking-tight">Policy Intelligence Hub</h1>
             </div>
           </div>
-          <div className="flex flex-wrap items-center justify-end gap-3">
+          <div className="flex flex-1 flex-wrap items-center justify-end gap-3">
             <ModeSelector mode={mode} onModeChange={setMode} />
             <ThemeToggle />
             <Link to="/about">
@@ -171,8 +171,8 @@ const Index = () => {
                 <span className="hidden sm:inline">About</span>
               </Button>
             </Link>
-            <Badge className="bg-success/10 text-success border-success/20">
-              <span className="mr-2 h-2 w-2 animate-pulse rounded-full bg-success" />
+            <Badge className="flex items-center gap-2 border-success/20 bg-success/10 text-success">
+              <span className="h-2 w-2 animate-pulse rounded-full bg-success" />
               Live
             </Badge>
           </div>
@@ -180,10 +180,10 @@ const Index = () => {
       </header>
 
       <main className="flex-1 overflow-y-auto">
-        <div className="container mx-auto px-4 py-6">
+        <div className="container mx-auto max-w-5xl space-y-8 px-4 py-6">
           {messages.length === 0 ? (
-            <div className="space-y-6">
-              <div className="rounded-3xl p-10 text-white shadow-glow gradient-hero">
+            <div className="space-y-8">
+              <div className="gradient-hero rounded-3xl p-10 text-white shadow-glow">
                 <div className="flex flex-col gap-4 text-balance md:flex-row md:items-end md:justify-between">
                   <div className="space-y-2">
                     <p className="text-sm uppercase tracking-[0.2em] text-white/80">Welcome</p>
@@ -218,13 +218,13 @@ const Index = () => {
               </div>
             </div>
           ) : (
-            <div className="space-y-6">
+            <div className="space-y-8">
               {messages.map((message) => {
                 const relatedPolicies = policies.filter((policy) => policy.messageId === message.id);
                 const firstPolicy = relatedPolicies[0];
 
                 return (
-                  <div key={message.id} className="space-y-4 animate-fade-up">
+                  <div key={message.id} className="space-y-4">
                     <ChatMessage message={message} />
 
                     {message.role === "assistant" && !message.isStreaming && (
@@ -247,7 +247,7 @@ const Index = () => {
                                 key={action.label}
                                 variant="outline"
                                 size="sm"
-                                className="gap-2 hover:bg-primary/10 hover:text-primary hover:border-primary"
+                                className="gap-2 rounded-full border-card-border/80 bg-card/70 backdrop-blur hover:border-primary hover:bg-primary/10 hover:text-primary"
                                 onClick={() => navigate(target)}
                               >
                                 <Icon className="h-4 w-4" />
@@ -263,20 +263,22 @@ const Index = () => {
               })}
 
               {isStreaming && (
-                <div className="flex items-center gap-3 rounded-2xl border border-border bg-card p-4 shadow-md">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-lg gradient-primary shadow-glow">
-                    <Bot className="h-5 w-5 text-primary-foreground" />
+                <Card className="glass border-card-border p-4">
+                  <div className="flex items-center gap-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-lg gradient-primary shadow-glow">
+                      <Bot className="h-5 w-5 text-primary-foreground" />
+                    </div>
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <Loader2 className="h-4 w-4 animate-spin text-primary" />
+                      Analyzing your request…
+                    </div>
                   </div>
-                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                    <Loader2 className="h-4 w-4 animate-spin text-primary" />
-                    Analyzing your request…
-                  </div>
-                </div>
+                </Card>
               )}
 
               {logs.length > 0 && (
-                <Card className="border-dashed border-border/80 bg-muted/40 p-4 text-xs text-muted-foreground">
-                  <p className="mb-2 font-medium text-foreground">Orchestrator log</p>
+                <Card className="glass border-dashed border-border/70 p-4 text-xs text-muted-foreground">
+                  <p className="mb-2 text-sm font-semibold text-foreground">Orchestrator log</p>
                   <div className="space-y-1">
                     {logs.map((entry, index) => (
                       <p key={`${entry}-${index}`}>{entry}</p>
@@ -290,15 +292,15 @@ const Index = () => {
       </main>
 
       <footer className="border-t border-border bg-card/95 backdrop-blur-sm">
-        <div className="container mx-auto px-4 py-4">
+        <div className="container mx-auto max-w-5xl px-4 py-4">
           <div className="flex flex-col gap-2">
-            <div className="flex items-end gap-3">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
               <Textarea
                 value={input}
                 onChange={(event) => setInput(event.target.value)}
                 onKeyDown={handleKeyDown}
                 placeholder={placeholder}
-                className="min-h-[60px] max-h-[200px] resize-none shadow-md"
+                className="min-h-[60px] max-h-[200px] flex-1 resize-none rounded-2xl border-card-border bg-card/80 shadow-md backdrop-blur"
                 rows={2}
                 disabled={chatMutation.isPending || isStreaming}
               />

--- a/src/pages/InfluencePage.tsx
+++ b/src/pages/InfluencePage.tsx
@@ -9,22 +9,29 @@ const InfluencePage = () => {
 
   return (
     <div className="min-h-screen bg-background">
-      <header className="sticky top-0 z-50 border-b border-border bg-card/95 backdrop-blur-sm">
-        <div className="container mx-auto flex items-center gap-4 px-4 py-4">
-          <Link to="/">
-            <Button variant="ghost" size="sm" className="gap-2">
-              <ArrowLeft className="h-4 w-4" />
-              Back to Chat
-            </Button>
-          </Link>
-          <div className="flex items-center gap-3">
-            <h1 className="text-lg font-bold">Influence Mapping &amp; Analysis</h1>
-            {billId && <Badge variant="outline">Bill {billId}</Badge>}
+      <header className="sticky top-0 z-50 border-b border-border bg-card/95 shadow-sm backdrop-blur-sm">
+        <div className="container mx-auto max-w-5xl px-4 py-4">
+          <div className="flex flex-wrap items-center gap-4">
+            <Link to="/">
+              <Button variant="ghost" size="sm" className="gap-2">
+                <ArrowLeft className="h-4 w-4" />
+                Back to Chat
+              </Button>
+            </Link>
+            <div className="hidden h-6 w-px bg-border sm:block" />
+            <div className="flex flex-wrap items-center gap-3">
+              <h1 className="text-lg font-bold">Influence Mapping &amp; Analysis</h1>
+              {billId && (
+                <Badge variant="outline" className="font-mono">
+                  Bill {billId}
+                </Badge>
+              )}
+            </div>
           </div>
         </div>
       </header>
 
-      <main className="container mx-auto px-4 py-8">
+      <main className="container mx-auto max-w-5xl px-4 py-8">
         <InfluenceTracker />
       </main>
     </div>


### PR DESCRIPTION
## Summary
- restyle the chat experience to match the new VS layout while keeping orchestrator-driven messaging, quick actions, and streaming feedback intact
- update supporting pages (DNA, Influence, About) and policy cards to use the refreshed gradients, glass surfaces, and responsive containers
- expand shared styles with gradient typography utilities to support the revised visual language

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e20344a3508332958800019a8ac508