### PR TITLE
Improve timeline and clause attribution data presentation

### DIFF
--- a/src/components/transparency/BlameView.tsx
+++ b/src/components/transparency/BlameView.tsx
@@ -7,6 +7,35 @@ type BlameViewProps = {
   entries: PolicyBlameEntry[];
 };
 
+const buildSummary = (entry: PolicyBlameEntry) => {
+  if (entry.summary?.trim()) {
+    return entry.summary.trim();
+  }
+
+  const fragments: string[] = [];
+  if (entry.actionType) {
+    fragments.push(entry.actionType);
+  }
+  if (entry.author) {
+    fragments.push(`by ${entry.author}`);
+  }
+  if (entry.actionDate) {
+    fragments.push(
+      `on ${new Date(entry.actionDate).toLocaleDateString(undefined, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      })}`
+    );
+  }
+
+  if (fragments.length === 0) {
+    return "No additional details were returned for this clause.";
+  }
+
+  return fragments.join(" ");
+};
+
 export const BlameView = ({ entries }: BlameViewProps) => {
   if (entries.length === 0) {
     return (
@@ -18,8 +47,11 @@ export const BlameView = ({ entries }: BlameViewProps) => {
 
   return (
     <div className="space-y-3">
-      {entries.map((entry) => (
-        <Card key={entry.sectionId} className="border-border hover:border-primary/50 transition-colors">
+      {entries.map((entry, index) => (
+        <Card
+          key={`${entry.sectionId ?? "section"}-${entry.heading ?? index}`}
+          className="border-border hover:border-primary/50 transition-colors"
+        >
           <CardContent className="p-4">
             <div className="flex items-start gap-3">
               <div className="flex-shrink-0 w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center">
@@ -40,9 +72,7 @@ export const BlameView = ({ entries }: BlameViewProps) => {
                   )}
                 </div>
 
-                {entry.summary && (
-                  <p className="text-sm text-foreground italic">"{entry.summary}"</p>
-                )}
+                <p className="text-sm text-foreground italic">{buildSummary(entry)}</p>
 
                 <div className="flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
                   {entry.author && (
@@ -52,7 +82,9 @@ export const BlameView = ({ entries }: BlameViewProps) => {
                     </div>
                   )}
                   {entry.actionType && <span>{entry.actionType}</span>}
-                  {entry.actionDate && <span>{new Date(entry.actionDate).toLocaleDateString()}</span>}
+                  {entry.actionDate && (
+                    <span>{new Date(entry.actionDate).toLocaleDateString()}</span>
+                  )}
                   {entry.sourceUri && (
                     <a
                       href={entry.sourceUri}

--- a/src/components/transparency/VersionTimeline.tsx
+++ b/src/components/transparency/VersionTimeline.tsx
@@ -7,82 +7,124 @@ type VersionTimelineProps = {
   onVersionSelect: (version: string) => void;
 };
 
+const formatChangeSummary = (entry: PolicyTimelineEntry) => {
+  const { changeSummary } = entry;
+  if (!changeSummary) return "Version recorded";
+  const added = changeSummary.added ?? 0;
+  const removed = changeSummary.removed ?? 0;
+  const modified = changeSummary.modified ?? 0;
+  if (added === 0 && removed === 0 && modified === 0) {
+    return "No textual changes detected";
+  }
+  const segments: string[] = [];
+  if (added > 0) segments.push(`+${added} words`);
+  if (removed > 0) segments.push(`-${removed} words`);
+  if (modified > 0) segments.push(`${modified} modified`);
+  return segments.join(" · ");
+};
+
+const getChangeColor = (changes: number) => {
+  if (changes === 0) return "bg-muted";
+  if (changes < 50) return "bg-success";
+  if (changes < 100) return "bg-warning";
+  return "bg-destructive";
+};
+
 export const VersionTimeline = ({
   versions,
   selectedVersion,
   onVersionSelect,
 }: VersionTimelineProps) => {
-  const getChangeColor = (changes: number) => {
-    if (changes === 0) return "bg-muted";
-    if (changes < 50) return "bg-success";
-    if (changes < 100) return "bg-warning";
-    return "bg-destructive";
-  };
+  if (!versions.length) {
+    return (
+      <div className="text-sm text-muted-foreground italic">
+        No version timeline was returned for this bill.
+      </div>
+    );
+  }
+
+  const sortedVersions = [...versions].sort((a, b) => {
+    const aDate = a.issuedOn ? new Date(a.issuedOn).getTime() : 0;
+    const bDate = b.issuedOn ? new Date(b.issuedOn).getTime() : 0;
+    return bDate - aDate;
+  });
+
+  const effectiveSelection =
+    selectedVersion ?? sortedVersions[0]?.versionId ?? sortedVersions[0]?.label;
 
   return (
     <div className="space-y-4">
       <div className="relative">
-        {/* Timeline line */}
         <div className="absolute left-4 top-0 bottom-0 w-0.5 bg-border" />
 
-        {/* Version items */}
         <div className="space-y-6">
-          {versions.map((version, idx) => (
-            <div
-              key={version.versionId}
-              className="relative flex items-start gap-4 cursor-pointer group"
-              onClick={() => onVersionSelect(version.versionId)}
-            >
-              {/* Timeline dot */}
-              <div
-                className={`relative z-10 w-8 h-8 rounded-full flex items-center justify-center transition-all ${
-                  selectedVersion === version.versionId
-                    ? "bg-primary ring-4 ring-primary/20"
-                    : "bg-card border-2 border-border group-hover:border-primary"
-                }`}
-              >
-                <span className="text-xs font-semibold text-foreground">
-                  {idx + 1}
-                </span>
-              </div>
+          {sortedVersions.map((version, idx) => {
+            const identifier = version.versionId ?? version.label ?? `${idx}`;
+            const changeMagnitude =
+              (version.changeSummary?.added ?? 0) +
+              (version.changeSummary?.removed ?? 0) +
+              (version.changeSummary?.modified ?? 0);
+            const isSelected = effectiveSelection === identifier;
 
-              {/* Version info */}
+            return (
               <div
-                className={`flex-1 p-4 rounded-lg border transition-all ${
-                  selectedVersion === version.versionId
-                    ? "border-primary bg-primary/5"
-                    : "border-border bg-card/50 group-hover:border-primary/50"
-                }`}
+                key={`${identifier}-${idx}`}
+                className="relative flex items-start gap-4 cursor-pointer group"
+                onClick={() => onVersionSelect(identifier)}
               >
-                <div className="flex items-center justify-between mb-2">
-                  <h3 className="font-semibold text-foreground">
-                    {version.label}
-                  </h3>
-                  {version.issuedOn && (
-                    <Badge variant="outline" className="text-xs">
-                      {new Date(version.issuedOn).toLocaleDateString()}
-                    </Badge>
-                  )}
+                <div
+                  className={`relative z-10 w-8 h-8 rounded-full flex items-center justify-center transition-all ${
+                    isSelected
+                      ? "bg-primary ring-4 ring-primary/20"
+                      : "bg-card border-2 border-border group-hover:border-primary"
+                  }`}
+                >
+                  <span className="text-xs font-semibold text-foreground">
+                    {idx + 1}
+                  </span>
                 </div>
-                <div className="flex items-center gap-3 text-sm">
-                  {version.changeSummary && (
+
+                <div
+                  className={`flex-1 p-4 rounded-lg border transition-all ${
+                    isSelected
+                      ? "border-primary bg-primary/5"
+                      : "border-border bg-card/50 group-hover:border-primary/50"
+                  }`}
+                >
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <h3 className="font-semibold text-foreground">
+                      {version.label}
+                    </h3>
+                    {version.issuedOn && (
+                      <Badge variant="outline" className="text-xs w-fit">
+                        {new Date(version.issuedOn).toLocaleDateString()}
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="mt-3 flex flex-col gap-2 text-sm text-muted-foreground">
                     <div className="flex items-center gap-2">
                       <div
-                        className={`h-2 w-12 rounded-full ${getChangeColor(
-                          (version.changeSummary.added ?? 0) +
-                            (version.changeSummary.removed ?? 0)
+                        className={`h-2 w-16 rounded-full ${getChangeColor(
+                          changeMagnitude
                         )}`}
                       />
-                      <span className="text-muted-foreground">
-                        +{version.changeSummary.added ?? 0} / -
-                        {version.changeSummary.removed ?? 0}
-                      </span>
+                      <span>{formatChangeSummary(version)}</span>
                     </div>
-                  )}
+                    {version.sourceUri && (
+                      <a
+                        href={version.sourceUri}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-xs text-primary hover:underline"
+                      >
+                        View source
+                      </a>
+                    )}
+                  </div>
                 </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- enhance the version timeline component with chronological sorting, richer change details, and source links for each version
- ensure clause attribution cards always show meaningful summaries and use stable keys for every entry
- adjust blame merging on the server to preserve more unique entries and order them chronologically

## Testing
- npm run lint *(fails: existing lint errors in legacy final-main and vs packages)*

------
https://chatgpt.com/codex/tasks/task_e_68e2301dd0fc8332907ae25df17f44db